### PR TITLE
Use SIMULATOR_OR_NOT from launch-files

### DIFF
--- a/ros/src/tl_detector/launch/tl_detector.launch
+++ b/ros/src/tl_detector/launch/tl_detector.launch
@@ -1,4 +1,7 @@
 <?xml version="1.0"?>
 <launch>
-    <node pkg="tl_detector" type="tl_detector.py" name="tl_detector" output="screen" cwd="node"/>
+    <node pkg="tl_detector" type="tl_detector.py" name="tl_detector" output="screen" cwd="node">
+    	<param name="SIMULATOR_OR_NOT" value="True" />
+    </node>
 </launch>
+

--- a/ros/src/tl_detector/launch/tl_detector_site.launch
+++ b/ros/src/tl_detector/launch/tl_detector_site.launch
@@ -1,5 +1,7 @@
 <?xml version="1.0"?>
 <launch>
-    <node pkg="tl_detector" type="tl_detector.py" name="tl_detector" output="screen" cwd="node"/>
+    <node pkg="tl_detector" type="tl_detector.py" name="tl_detector" output="screen" cwd="node">
+      <param name="SIMULATOR_OR_NOT" value="False" />
+    </node>
     <node pkg="tl_detector" type="light_publisher.py" name="light_publisher" output="screen" cwd="node"/>
 </launch>

--- a/ros/src/tl_detector/tl_detector.py
+++ b/ros/src/tl_detector/tl_detector.py
@@ -340,7 +340,6 @@ class TLDetector(object):
                     seg_bottom = (l[2 * int(tl_img_height / 3):3 * int(tl_img_height / 3), :] > L_THRES).sum()
                     
                     # check if top segment is greater than the bottom segment, otherwise it's not red light
-                    global self.SIMULATOR_OR_NOT
                     
                     if ((seg_top > seg_bottom) and (seg_top > seg_middle)) or (self.SIMULATOR_OR_NOT == True):
                         # now the top segment is the highest, but by chance this could mean that some very bright object or the sun could be shining on the top part of the traffic light

--- a/ros/src/tl_detector/tl_detector.py
+++ b/ros/src/tl_detector/tl_detector.py
@@ -340,6 +340,7 @@ class TLDetector(object):
                     seg_bottom = (l[2 * int(tl_img_height / 3):3 * int(tl_img_height / 3), :] > L_THRES).sum()
                     
                     # check if top segment is greater than the bottom segment, otherwise it's not red light
+                    global self.SIMULATOR_OR_NOT
                     
                     if ((seg_top > seg_bottom) and (seg_top > seg_middle)) or (self.SIMULATOR_OR_NOT == True):
                         # now the top segment is the highest, but by chance this could mean that some very bright object or the sun could be shining on the top part of the traffic light


### PR DESCRIPTION
Had to change 
- the launch-files
- tl_detector.py: create self.SIMULATOR_OR_NOT and replace SIMULATOR_OR_NOT with self.SIMULATOR_OR_NOT
- tl_detector,py: delete original line 339: global SIMULATOR_OR_NOT (syntax error)
